### PR TITLE
Bump Ardalis.Specification.EntityFrameworkCore from 8.0.0 to 9.3.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageVersion Include="Ardalis.ApiEndpoints" Version="4.1.0" />
     <PackageVersion Include="Ardalis.GuardClauses" Version="4.5.0" />
-    <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="8.0.0" />
+    <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="9.3.1" />
     <PackageVersion Include="Ardalis.Result" Version="10.1.0" />
     <PackageVersion Include="Ardalis.Specification" Version="8.0.0" />
     <PackageVersion Include="Ardalis.ListStartupServices" Version="1.1.4" />


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: Ardalis.Specification.EntityFrameworkCore dependency-version: 9.3.1 dependency-type: direct:production update-type: version-update:semver-major ...